### PR TITLE
Fix #794 Don't filter away the entry itself

### DIFF
--- a/src/main/resources/lib/enonic/react4xp/dependencies/readComponentChunkNames.ts
+++ b/src/main/resources/lib/enonic/react4xp/dependencies/readComponentChunkNames.ts
@@ -70,7 +70,7 @@ export function readComponentChunkNames(entryNames :OneOrMore<React4xpNamespace.
 
                     throw new Error(`Unexpected 'assets' structure in ${COMPONENT_STATS_FILENAME}: ${JSON.stringify(data.assets)}`);
                 })
-                .filter((asset :string) => !endsWith(asset, ".map") && asset !== myself)
+                .filter((asset :string) => !endsWith(asset, ".map"))
                 .forEach((asset :string) => {
                     if (output.indexOf(asset) === -1) {
                         output.push(asset);


### PR DESCRIPTION
This fixes the development build. Why the code was there probably had something to do with eager loading. Side-note: Some of the JS code probably belongs in Java.